### PR TITLE
Mark synthetic functions as such

### DIFF
--- a/src/code_dom.py
+++ b/src/code_dom.py
@@ -725,6 +725,7 @@ class DOMPreprocessorIf(DOMElement):
         self.else_children = []
         clone = DOMElement.clone_without_children(self)
         self.else_children = temp_else_children
+        self.is_synthetic = True
         return clone
 
     def __str__(self):
@@ -1376,6 +1377,7 @@ class DOMFunctionDeclaration(DOMElement):
         #                                         (see mod_generate_default_argument_functions)
         self.is_manual_helper = False  # Set if this is a manually-added helper function (see
         # mod_add_helper_functions for more details)
+        self.is_synthetic = False
 
     # Parse tokens from the token stream given
     @staticmethod
@@ -1608,6 +1610,7 @@ class DOMFunctionDeclaration(DOMElement):
         clone = DOMElement.clone(self)
         self.original_class = old_original_class
         clone.original_class = old_original_class
+        self.is_synthetic = True
         return clone
 
     # Write this element out as C code

--- a/src/generators/gen_metadata.py
+++ b/src/generators/gen_metadata.py
@@ -246,6 +246,7 @@ def emit_function(function):
     result["is_manual_helper"] = function.is_manual_helper  # True for functions that aren't in the C++ API originally
     #                                                         but have been added manually here to provide helpful
     #                                                         extra functionality
+    result["is_synthetic"] = function.is_synthetic
 
     add_comments(function, result)
     add_preprocessor_conditionals(function, result)


### PR DESCRIPTION
I came to a need of this when i tried to consume API json file directly and write a generator that outputs pybind11 code to produce python bindings. In such case it is required to know which functions actually exist in the library and should be wrapped and which ones are generated. Due to how pybind11 works there is no need to wrap a C api and i can feed C++ api to it directly. I am not sure if this is complete/correct so please review.