### PR TITLE
Allow running dear_bindings.py from anywhere

### DIFF
--- a/dear_bindings.py
+++ b/dear_bindings.py
@@ -414,6 +414,8 @@ if __name__ == '__main__':
 
     print("Dear Bindings: parse Dear ImGui headers, convert to C and output metadata.")
 
+    default_template_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "src", "templates")
+
     parser = argparse.ArgumentParser(
                         add_help=True,
                         epilog='Result code 0 is returned on success, 1 on conversion failure and 2 on '
@@ -425,7 +427,7 @@ if __name__ == '__main__':
                         help='Path to output files (generally cimgui). This should have no extension, '
                              'as <output>.h, <output>.cpp and <output>.json will be written.')
     parser.add_argument('-t', '--templatedir',
-                        default="./src/templates",
+                        default=default_template_dir,
                         help='Path to the implementation template directory (default: ./src/templates)')
 
     if len(sys.argv)==1:


### PR DESCRIPTION
Running the bindings generator failed when running it from another directory:
e.g.
```
python ~/projects/dear_bindings/dear_bindings.py -o cimgui imgui/imgui.h
```
failed with:
```
Template file ./src/templates/common-header-template.h could not be found (note that template file names are expected to match source file names, so if you have renamed imgui.h you will need to rename the template as well). The common template file is included regardless of source file name.
Exception during conversion:
Traceback (most recent call last):
  File "/home/maarten/projects/dear_bindings/dear_bindings.py", line 439, in <module>
    convert_header(args.src, args.output, args.templatedir)
  File "/home/maarten/projects/dear_bindings/dear_bindings.py", line 390, in convert_header
    insert_header_templates(file, template_dir, src_file_name_only, ".h", expansions)
  File "/home/maarten/projects/dear_bindings/dear_bindings.py", line 48, in insert_header_templates
    insert_single_template(dest_file,
  File "/home/maarten/projects/dear_bindings/dear_bindings.py", line 36, in insert_single_template
    sys.exit(2)
SystemExit: 2
```

Giving the template directory a default absolute path fixed this.