### PR TITLE
readme: add tested backends

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -199,9 +199,15 @@ To convert a backend header, use `--backend` on the command line - for example:
 python dear_bindings.py --backend -o cimgui_impl_opengl3 imgui\backends\imgui_impl_opengl3.h
 ```
 
-This has had _very_ minimal testing as yet (basically, all backends except OSX/Metal convert cleanly, and the SDL and OpenGL3 backends seem to compile), but the results look reasonable. Feedback on how well this works would be most appreciated.
+Tested Backends:
+* Win32
+* DirectX 11
+* DirectX 12
+* OpenGL 3
+* Vulkan
 
-I've left out the Metal/OSX backends for now as the Objective-C code in them looks like it would probably make life painful, and I'm not sure there's even a use-case for them here (please let me know if you have one).
+All other backends (except Metal/OSX) at least appear to convert cleanly with reasonable looking results. Further testing (adding to the list above) would be most appreciated.
+The Metal/OSX backends have been excluded for now as the Objective-C code in them looks like it would probably make life painful. Please provide feedback if there is a use case for these.
 
 Software using Dear Bindings
 ----------------------------


### PR DESCRIPTION
I was initially hesitant to use dear_bindings because of the "experimental" designation for the backends. After filing a few minor issues (with quick fixes - thank you @ShironekoBen), the experience was actually super positive. I'm very thankful to this project for allowing me to easily use the awesome ImGui inside my C projects!

The experience has been stable across dear_bindings and imgui changes for the months that I've been using it, and the generated headers have all been nicely readable. Using dear_bindings for Win32, DX11, DX12, OpenGL3, and Vulkan, I have all of these compiling and working within my custom C renderer. 

To give back and kickstart the effort to move this beyond experimental, I've added a list of tested backends. I've also depersonalized some of the wording. At least for the backends that I've tested, I think it is in a good state that more people can comfortably start to adopt.