### PR TITLE
Mark SDL gamepad typedefs as unmodified

### DIFF
--- a/dear_bindings.py
+++ b/dear_bindings.py
@@ -272,7 +272,9 @@ def convert_header(
     # SDL backend forward-declared types
     mod_mark_structs_as_using_unmodified_name_for_typedef.apply(dom_root,
                                                                 ["SDL_Window",
-                                                                 "SDL_Renderer"
+                                                                 "SDL_Renderer",
+                                                                 "SDL_Gamepad",
+                                                                 "_SDL_GameController"
                                                                  ])
 
 


### PR DESCRIPTION
The `SDL_Gamepad` and `_SDL_GameController` typedefs were not marked as unmodified and so got the "_t" suffix which does not match SDL's actual types.