### PR TITLE
added dependabot file to auto upgrading github actions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      github-action-deps:
+        applies-to: "version-updates"
+        patterns: ["*"]


### PR DESCRIPTION
just some low-hanging fruit, fixes following issues :)
and no dependabot is not going to create 20 million PRs, it will group them into 1 PR at max.

![image](https://github.com/user-attachments/assets/fa6f4556-22d5-4f8e-835b-dccb9696d721)
