### PR TITLE
Add option to preserve C++ references

### DIFF
--- a/dear_bindings.py
+++ b/dear_bindings.py
@@ -89,6 +89,7 @@ def convert_header(
         template_dir,
         no_struct_by_value_arguments,
         no_generate_default_arg_functions,
+        no_convert_references_to_pointers,
         generate_unformatted_functions,
         is_backend,
         imgui_include_dir,
@@ -224,7 +225,8 @@ def convert_header(
     mod_set_arguments_as_nullable.apply(dom_root, ["fmt"], False)  # All arguments called "fmt" are non-nullable
     mod_remove_operators.apply(dom_root)
     mod_remove_heap_constructors_and_destructors.apply(dom_root)
-    mod_convert_references_to_pointers.apply(dom_root)
+    if not no_convert_references_to_pointers:
+        mod_convert_references_to_pointers.apply(dom_root)
     if no_struct_by_value_arguments:
         mod_convert_by_value_struct_args_to_pointers.apply(dom_root)
     # Assume IM_VEC2_CLASS_EXTRA and IM_VEC4_CLASS_EXTRA are never defined as they are likely to just cause problems
@@ -698,6 +700,9 @@ if __name__ == '__main__':
     parser.add_argument('--nogeneratedefaultargfunctions',
                         action='store_true',
                         help='Do not generate function variants with implied default values')
+    parser.add_argument('--noconvertreferencestopointers',
+                        action='store_true',
+                        help='Do not convert references to pointers')
     parser.add_argument('--generateunformattedfunctions',
                         action='store_true',
                         help='Generate unformatted variants of format string supporting functions')
@@ -786,6 +791,7 @@ if __name__ == '__main__':
             args.templatedir,
             args.nopassingstructsbyvalue,
             args.nogeneratedefaultargfunctions,
+            args.noconvertreferencestopointers,
             args.generateunformattedfunctions,
             args.backend,
             args.imgui_include_dir,

--- a/src/generators/gen_metadata.py
+++ b/src/generators/gen_metadata.py
@@ -116,6 +116,8 @@ def emit_type_comprehension_pointer(pointer):
 
     if hasattr(pointer, 'nullable'):
         result["is_nullable"] = pointer.nullable
+    if hasattr(pointer, 'reference'):
+        result["is_reference"] = pointer.reference
 
     result["inner_type"] = emit_type_comprehension_element(pointer.target)
 

--- a/src/type_comprehension/type_comprehender.py
+++ b/src/type_comprehension/type_comprehender.py
@@ -154,7 +154,7 @@ def get_type_description(type_str):
             pass  # Ignore whitespace
         elif c == '(':
             pass  # Ignore group starts
-        elif (c == '*') or (c == '^'):
+        elif (c == '*') or (c == '^') or (c == "&"):
             pass  # Ignore pointers for the moment
         elif c == '[':
             break  # If we hit an array declaration, then there is no field name
@@ -280,7 +280,7 @@ def get_type_description(type_str):
                 buffered_storage_classes.append(
                     type_comprehension.TCStorageClass(type_comprehension.storage_class.StorageClass.mutable))
                 left_parse_point -= 7
-            elif (c == '*') or (c == '^'):  # ^ indicates a non-nullable pointer
+            elif (c == '*') or (c == '^') or (c == "&"):  # ^ indicates a non-nullable pointer
                 # Pointer
                 left_parse_point -= 1
                 # print("Pointer")
@@ -288,6 +288,8 @@ def get_type_description(type_str):
                 pointer_type.storage_classes = buffered_storage_classes
                 if c == '^':
                     pointer_type.nullable = False
+                if c == "&":
+                    pointer_type.reference = True
                 current_type = chain_type(current_type, pointer_type)
                 buffered_storage_classes = []
             elif c == '(':


### PR DESCRIPTION
Hi,

While generating bindings I found helpful to know if a pointer is a raw pointer or a reference in the original code.
I added an option to skip the convert references to pointers step and preserve this information in the generated JSON.

There is no change in behavior if the flag is not set (default).

Example before:
```
            "name": "ImGui_GetIO",
            "original_fully_qualified_name": "ImGui::GetIO",
            "return_type": {
                "declaration": "ImGuiIO*",
                "description": {
                    "kind": "Pointer",
                    "is_nullable": false,
                    "inner_type": {
                        "kind": "User",
                        "name": "ImGuiIO"
                    }
                }
            },
```

Example using `--nonoconvertreferencestopointers`:
```
            "name": "ImGui_GetIO",
            "original_fully_qualified_name": "ImGui::GetIO",
            "return_type": {
                "declaration": "ImGuiIO&",
                "description": {
                    "kind": "Pointer",
                    "is_reference": true,
                    "inner_type": {
                        "kind": "User",
                        "name": "ImGuiIO"
                    }
                }
            },
```

