### PR TITLE
Copy the returned value to a temporary variable when the function needs to call to va_end

### DIFF
--- a/src/generators/gen_function_stubs.py
+++ b/src/generators/gen_function_stubs.py
@@ -213,10 +213,18 @@ def generate(dom_root, file, imgui_custom_types, indent=0, custom_varargs_list_s
 
         # Write body containing thunk call
 
+        # We need to check if the function has to copy the result to a temporary variable and then
+        # return it later, this happens with varargs as we have to call va_end before returning
+        returns_temp_result = False
+        
         if (function.return_type is None) or (function.return_type.to_c_string() == "void"):
             thunk_call = ""
         else:
-            thunk_call = "return "
+            if uses_varargs:
+                returns_temp_result = True
+                thunk_call = "auto temp_result = "
+            else:
+                thunk_call = "return "
 
         # Generate return type cast if necessary
 
@@ -332,6 +340,9 @@ def generate(dom_root, file, imgui_custom_types, indent=0, custom_varargs_list_s
 
         if uses_varargs:
             write_c_line(file, indent, write_context, "va_end(args);")
+        
+        if returns_temp_result:
+            write_c_line(file, indent, write_context, "return temp_result;")
 
         # Close off body
 


### PR DESCRIPTION
I've noticed that some functions do a return before the va_end, example:
```
CIMGUI_API bool  cimgui::igTreeNodeExStr(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, ...)
{
    va_list args;
    va_start(args, fmt);
    return ::ImGui::TreeNodeExV(str_id, flags, fmt, args);
    va_end(args);
}

CIMGUI_API bool  cimgui::igTreeNodeExPtr(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, ...)
{
    va_list args;
    va_start(args, fmt);
    return ::ImGui::TreeNodeExV(ptr_id, flags, fmt, args);
    va_end(args);
}
```
I've fixed it by copying returned value to a temporary variable and returning it later (only in the case of functions taking var args), although the generator can be simplified if it always copies the returning value to a temporary.

New result:

```
CIMGUI_API bool  cimgui::igTreeNodeExStr(const char* str_id, ImGuiTreeNodeFlags flags, const char* fmt, ...)
{
    va_list args;
    va_start(args, fmt);
    auto temp_result = ::ImGui::TreeNodeExV(str_id, flags, fmt, args);
    va_end(args);
    return temp_result;
}

CIMGUI_API bool  cimgui::igTreeNodeExPtr(const void* ptr_id, ImGuiTreeNodeFlags flags, const char* fmt, ...)
{
    va_list args;
    va_start(args, fmt);
    auto temp_result = ::ImGui::TreeNodeExV(ptr_id, flags, fmt, args);
    va_end(args);
    return temp_result;
}
```
