### PR TITLE
BuildAllBindings.*: add sdlgpu3

### DIFF
--- a/BuildAllBindings.bat
+++ b/BuildAllBindings.bat
@@ -42,6 +42,7 @@ for %%n in (
 	sdl2
 	sdlrenderer2
 	sdl3
+	sdlgpu3
 	sdlrenderer3
 	vulkan
 	wgpu

--- a/BuildAllBindings.sh
+++ b/BuildAllBindings.sh
@@ -24,7 +24,6 @@ echo
 echo "Processing imgui_internal.h"
 echo
 python3 dear_bindings.py -o "$OUTPUT_PATH/dcimgui_internal" --include "$IMGUI_PATH/imgui.h" "$IMGUI_PATH/imgui_internal.h" || { echo "Processing failed"; exit 1; }
-
 # Process backends
 for backend in \
     allegro5 \
@@ -40,6 +39,7 @@ for backend in \
     sdl2 \
     sdlrenderer2 \
     sdl3 \
+    sdlgpu3 \
     sdlrenderer3 \
     vulkan \
     wgpu \


### PR DESCRIPTION
Hi,

I've found that generating bindings for sdlgpu3 works and aren't triggered by BuildAllBindings.* scripts.
May be there is reason to not generate by default or maybe it was just forgotten, so here I am !

I successfully ported original C++ example_sdl3_sdlgpu3 to C using them. Runs at least on my Linux Debian 13. I will PR that too (separately).
I've found that metal, null and osx are still missing in the list of the scripts, but templates are also missing, so it fails.

Thanks for everything,