### PR TITLE
Add generated backends to daily builds + release ZIP (#109)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         sudo pip3 install ply
 
-    - name: Generate cimgui
+    - name: Generate dcimgui
       run: >- 
         ${{ 
           format('python3 dear_bindings.py --output dcimgui {0} --generateunformattedfunctions imgui/imgui.h', 
@@ -58,6 +58,28 @@ jobs:
           format('python3 dear_bindings.py --output dcimgui_internal {0} --generateunformattedfunctions --include imgui/imgui.h imgui/imgui_internal.h', 
             matrix.flag_nogeneratedefaultargfunctions == 'nogeneratedefaultargfunctions' && '--nogeneratedefaultargfunctions' || '') 
         }}
+    - name: Generate dcimgui_impl_xxx backends
+      run: |
+        mkdir backends
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_allegro5      imgui/backends/imgui_impl_allegro5.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_android       imgui/backends/imgui_impl_android.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_dx9           imgui/backends/imgui_impl_dx9.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_dx10          imgui/backends/imgui_impl_dx10.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_dx11          imgui/backends/imgui_impl_dx11.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_dx12          imgui/backends/imgui_impl_dx12.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_glfw          imgui/backends/imgui_impl_glfw.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_glut          imgui/backends/imgui_impl_glut.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_null          imgui/backends/imgui_impl_null.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_opengl2       imgui/backends/imgui_impl_opengl2.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_opengl3       imgui/backends/imgui_impl_opengl3.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_sdl2          imgui/backends/imgui_impl_sdl2.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_sdlrenderer2  imgui/backends/imgui_impl_sdlrenderer2.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_sdl3          imgui/backends/imgui_impl_sdl3.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_sdlgpu3       imgui/backends/imgui_impl_sdlgpu3.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_sdlrenderer3  imgui/backends/imgui_impl_sdlrenderer3.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_vulkan        imgui/backends/imgui_impl_vulkan.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_wgpu          imgui/backends/imgui_impl_wgpu.h
+        python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_win32         imgui/backends/imgui_impl_win32.h
     - name: Build
       run: |
         ${{ matrix.compiler }}                  \
@@ -84,3 +106,5 @@ jobs:
         path: |
           dcimgui.*
           dcimgui_internal.*
+          backends/dcimgui_impl*.cpp
+          backends/dcimgui_impl*.h

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,11 +86,11 @@ jobs:
       run: |
         sudo pip3 install ply
 
-    - name: generate_cimui
+    - name: generate_dcimgui
       if: ${{ env.DO_RELEASE == '1' }}
       run: python3 dear_bindings.py --output dcimgui --generateunformattedfunctions imgui/imgui.h 
 
-    - name: generate_cimui_nogeneratedefaultargfunctions
+    - name: generate_dcimgui_nogeneratedefaultargfunctions
       if: ${{ env.DO_RELEASE == '1' }}
       run: python3 dear_bindings.py --output dcimgui_nodefaultargfunctions --nogeneratedefaultargfunctions --generateunformattedfunctions imgui/imgui.h
 
@@ -101,6 +101,30 @@ jobs:
     - name: generate_dcimgui_nodefaultargfunctions_internal
       if: ${{ env.DO_RELEASE == '1' }}
       run: python3 dear_bindings.py --output dcimgui_nodefaultargfunctions_internal --nogeneratedefaultargfunctions --generateunformattedfunctions --include imgui/imgui.h imgui/imgui_internal.h
+
+    - name: generate_dcimgui_backends
+      if: ${{ env.DO_RELEASE == '1' }}
+      run: |
+          mkdir backends
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_allegro5      imgui/backends/imgui_impl_allegro5.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_android       imgui/backends/imgui_impl_android.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_dx9           imgui/backends/imgui_impl_dx9.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_dx10          imgui/backends/imgui_impl_dx10.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_dx11          imgui/backends/imgui_impl_dx11.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_dx12          imgui/backends/imgui_impl_dx12.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_glfw          imgui/backends/imgui_impl_glfw.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_glut          imgui/backends/imgui_impl_glut.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_null          imgui/backends/imgui_impl_null.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_opengl2       imgui/backends/imgui_impl_opengl2.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_opengl3       imgui/backends/imgui_impl_opengl3.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_sdl2          imgui/backends/imgui_impl_sdl2.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_sdlrenderer2  imgui/backends/imgui_impl_sdlrenderer2.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_sdl3          imgui/backends/imgui_impl_sdl3.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_sdlgpu3       imgui/backends/imgui_impl_sdlgpu3.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_sdlrenderer3  imgui/backends/imgui_impl_sdlrenderer3.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_vulkan        imgui/backends/imgui_impl_vulkan.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_wgpu          imgui/backends/imgui_impl_wgpu.h
+          python3 dear_bindings.py --backend --include imgui/imgui.h --output backends/dcimgui_impl_win32         imgui/backends/imgui_impl_win32.h
 
     - name: Generate ZIP file
       if: ${{ env.DO_RELEASE == '1' }}
@@ -122,4 +146,24 @@ jobs:
           dcimgui_internal.*
           dcimgui_nodefaultargfunctions.*
           dcimgui_nodefaultargfunctions_internal.*
+          backends/dcimgui_impl_*.cpp
+          backends/dcimgui_impl_*.h
+          backends/dcimgui_impl_allegro5.json
+          backends/dcimgui_impl_android.json
+          backends/dcimgui_impl_dx9.json
+          backends/dcimgui_impl_dx10.json
+          backends/dcimgui_impl_dx11.json
+          backends/dcimgui_impl_dx12.json
+          backends/dcimgui_impl_glut.json
+          backends/dcimgui_impl_null.json
+          backends/dcimgui_impl_opengl2.json
+          backends/dcimgui_impl_opengl3.json
+          backends/dcimgui_impl_sdl2.json
+          backends/dcimgui_impl_sdlrenderer2.json
+          backends/dcimgui_impl_sdl3.json
+          backends/dcimgui_impl_sdlgpu3.json
+          backends/dcimgui_impl_sdlrenderer3.json
+          backends/dcimgui_impl_vulkan.json
+          backends/dcimgui_impl_wgpu.json
+          backends/dcimgui_impl_win32.json
           ${{ env.RELEASE_TAG }}.zip

--- a/docs/Changelog.txt
+++ b/docs/Changelog.txt
@@ -1,7 +1,8 @@
 --- v0.18 WIP
 
 * Added support for SDLGPU3 backend + SDL3+SDLGPU3 example.
-* Added support for NULL backend.
+* Added support for NULL backend. (#110)
+* Added all generated backends to GitHub release packages. (#109)
 
 --- v0.17
 


### PR DESCRIPTION
Daily builds include .cpp/.h file, release also include .json (I guess kinda arbitrary and mostly due to noise of calling all those)
I think Workflow could be reworked to call the script script to remove redundancy.
@memononen

Release ZIP changes technically untested on server.